### PR TITLE
Enhance/rem

### DIFF
--- a/build/configs/alias.config.js
+++ b/build/configs/alias.config.js
@@ -6,6 +6,7 @@ const Webpack = require('webpack');
 
 module.exports = {
   config: {
+    '@root': path.resolve(__dirname, '../../'),
     '@build': path.resolve(__dirname, '../../build/'),
     '@guide': path.resolve(__dirname, '../../build/guide/'),
     '@src':  path.resolve(__dirname, '../../src/'),

--- a/build/configs/css/css.postcss-rem.plugin.js
+++ b/build/configs/css/css.postcss-rem.plugin.js
@@ -1,0 +1,31 @@
+const postcss = require('postcss');
+const path = require('path');
+
+module.exports = postcss.plugin('postcss-rems', (options) => {
+  options = options || {};
+  let baseSize = undefined;
+
+  return root => {
+    root.walkRules(':root', rule => {
+      rule.walkDecls(decl => {
+        if (decl.prop === '--type-size--default') {
+          baseSize = parseInt(decl.value, 10);
+        }
+      })
+    })
+
+    root.walkDecls(decls => {
+      if (decls.value.indexOf('rem(') !== -1) {
+
+        let instances = decls.value.match(/rem\(.*?\)/g);
+        let i = instances.length;       
+        while (i--) {
+          try {
+            let rawUnit = parseInt(instances[i].replace(/(.*)\((.*)\)/g, '$2'), 10);
+            decls.value = decls.value.replace(instances[i], `${rawUnit / baseSize}rem`);
+          } catch (err) { console.log(err); }
+        }
+      }
+    })
+  }
+});

--- a/build/configs/css/css.postcss.config.js
+++ b/build/configs/css/css.postcss.config.js
@@ -29,6 +29,7 @@ const variables = require('./css.postcss-vars.plugin.js');
 const minification = require('cssnano');
 const exporting = require('./css.postcss-exports.plugin.js');
 const media = require('./css.postcss-media.plugin.js');
+const rems = require('./css.postcss-rem.plugin.js');
 const mediaPacker = require('css-mqpacker');
 const removeRoots = require('./css.postcss-roots.plugin.js');
 
@@ -45,6 +46,7 @@ module.exports = {
     nested(),       // Allows for nested selectors
     extend(),       // Allows for CSS @extend
     mixins(),       // Allows for CSS @mixins
+    rems(),         // Allows for CSS rem()
     removeRoots(),  // Cleans up leftover :root declarations.
     mediaPacker(),   // Allows for the consolidation of @media queries
     minification(), // Minification of our final CSS results.

--- a/build/guide/partials/welcome/guide__welcome.jsx
+++ b/build/guide/partials/welcome/guide__welcome.jsx
@@ -20,8 +20,6 @@ export const Guide__welcome = (props) => {
 
   return (
     <Rhythm tagName="section" className="guide__welcome">
-      <Heading>Welcome to Unslate!</Heading>
-      <p>Unslated is Connective DX&apos;s in-house toolset for making static websites and atomic styleguides. It&apos;s great for producing static web assets with an emphasis on atomic driven architecture.</p>
       <Tabs defaultTab="0" className="card__deck" defaultTab={false}>
         <Card className="tabs__trigger fall-flip" color="green">
           <Card__body className="js-size" tagName="h2" />
@@ -62,8 +60,7 @@ export const Guide__welcome = (props) => {
         </Card>
         <Tabs__section />
       </Tabs>
-
-      <Heading level="h3">About Unslated</Heading>
+      <Heading>Welcome to Unslated!</Heading>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sem pellentesque, volutpat dolor eget, accumsan quam. Donec ac porta mauris. Suspendisse blandit fringilla viverra. Vivamus sodales nisi et leo gravida, id imperdiet augue tristique. Mauris ultrices eros non sollicitudin finibus. Cras consequat placerat turpis sit amet porttitor. Cras efficitur ligula sit amet nibh convallis feugiat. Integer sem justo, mollis a risus sit amet, mattis venenatis mauris. Morbi rhoncus sem urna, id condimentum elit vehicula ut. Curabitur id nibh ut arcu iaculis convallis nec nec ipsum. Pellentesque feugiat vestibulum feugiat. Phasellus nisl mi, blandit vitae ipsum eu, scelerisque volutpat lorem. Sed condimentum felis nunc, nec commodo purus efficitur non. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
       <p>Cras tincidunt tempor mi, quis porttitor est tempor ac. Maecenas sit amet tincidunt mi, ut pharetra mauris. Duis tempor elit et mi tristique, eget rhoncus turpis scelerisque. Nulla auctor posuere purus, eu pellentesque mi rhoncus vel. Nulla tincidunt luctus nulla. Integer efficitur molestie mauris, a eleifend ipsum malesuada vel. Ut id bibendum neque. Nulla quis nulla mattis, tempus lectus vitae, efficitur ligula. Nullam elementum turpis velit, nec semper lacus efficitur quis. Nunc venenatis orci in imperdiet malesuada. Praesent a nunc nec nisi lobortis euismod ac ut ipsum. Fusce ut nisi aliquet, posuere felis rutrum, bibendum justo. Maecenas gravida efficitur elementum. Cras ultrices elit diam, in consequat nisl dignissim vel.</p>
       <Heading level="h3">Getting Started</Heading>

--- a/src/elements/atoms/Heading/Heading.css
+++ b/src/elements/atoms/Heading/Heading.css
@@ -5,15 +5,15 @@
   line-height: 1em;
 
   /* weights */
-  &--thin { font-weight: 300; }
-  &--bold { font-weight: 700; }
+  &--thin   { font-weight: 300; }
+  &--bold   { font-weight: 700; }
   &--medium { font-weight: 500; }
 
   /* levels */
-  &--h1 { font-size: 2em; }
-  &--h2 { font-size: 1.6em; }
-  &--h3 { font-size: 1.4em; }
-  &--h4 { font-size: 1.3em; }
-  &--h5 { font-size: 1.2em; }
-  &--h6 { font-size: 1.1em; }
+  &--h1 { font-size: rem(28px); }
+  &--h2 { font-size: rem(24px); }
+  &--h3 { font-size: rem(22px); }
+  &--h4 { font-size: rem(20px); }
+  &--h5 { font-size: rem(18px); }
+  &--h6 { font-size: rem(16px); }
 }

--- a/src/elements/atoms/Root/Root.css
+++ b/src/elements/atoms/Root/Root.css
@@ -6,8 +6,8 @@
 }
 
 body {
+  font-size: var(--type-size--default);
   font-family: var(--font-family--default);
-  font-size: responsive var(--type-responsive-min) var(--type-responsive-max);
   font-range: var(--type-responsive-range);
   line-height: var(--type-line-height);
 }

--- a/src/elements/molecules/Tabs/Tabs.css
+++ b/src/elements/molecules/Tabs/Tabs.css
@@ -12,11 +12,19 @@
 
   &__trigger {
     &.tabs-state--open {
-      & + .tabs__target { height: auto; opacity: 1; }
+      & + .tabs__target { 
+        height: auto;
+        opacity: 1;
+        visibility: visible;
+      }
     }
   }
 
-  &__target { height: 0; opacity: 0; }
+  &__target {
+    height: 0;
+    opacity: 0;
+    visibility: hidden;
+  }
 
   /* Tabs alignment & justification */
   &-align {
@@ -34,14 +42,14 @@
       grid-template-columns: 15% 85%;
 
        .tabs__trigger { grid-column-start: 1; }
-      .tabs__target { grid-column-start: 2; }
+      .tabs__target   { grid-column-start: 2; }
     }
 
     &--right {
       grid-template-columns: 85% 15%;
 
        .tabs__trigger { grid-column-start: 2; }
-      .tabs__target { grid-column-start: 1; }
+      .tabs__target   { grid-column-start: 1; }
     }
 
     /* Order is controlled via JS Containre with the CSS order: X; prop */
@@ -50,12 +58,12 @@
 
     &--top {
       .tabs__trigger { order: 1; }
-      .tabs__target { order: 2; }
+      .tabs__target  { order: 2; }
     }
 
     &--bottom {
-      .tabs__trigger{ order: 2;  }
-      .tabs__target { order: 1; }      
+      .tabs__trigger { order: 2;  }
+      .tabs__target  { order: 1; }      
     }
   }
 

--- a/src/variables/fonts.css
+++ b/src/variables/fonts.css
@@ -2,7 +2,7 @@
   Define font variables.
 */
 
-:root {
+:root {  
   /* Individual font names */
   --font-name--default: 'Helvetica Neue';
 
@@ -16,4 +16,5 @@
   --font-weight--thin: 300;
   --font-weight--normal: 500;
   --font-weight--bold: 700;
+
 }

--- a/src/variables/type.css
+++ b/src/variables/type.css
@@ -3,6 +3,9 @@
 */
 
 :root {
+  /* Base body font size */
+  --type-size--default: 16px;
+
   /* Base body line height for the body element. */
   --type-line-height: 1.4;
 


### PR DESCRIPTION
Adding rem() method to CSS via a custom POSTCSS plugin that hooks into the variables/type.css base font size variable and calculates / replaces all instances of rem(XXpx) with XXrem across all sheets. This includes instances where prop: rem(XXpx) rem(XXpx) occur.

#85 

I've also included @root to the alias config to support rolling a number of configurations up into the package file vs across the file system.

Lastly, this fixes Tabs by using a hight:0/auto visibility: hidden/visible to allow inner content (if needed) to still be measured while it is visually hidden, but not cover any content while hidden.