### PR TITLE
Enhance/devOnlyProps

### DIFF
--- a/build/guide/partials/examples/guide__examples.jsx
+++ b/build/guide/partials/examples/guide__examples.jsx
@@ -80,8 +80,11 @@ export const Guide__examples = (props) => {
             }).replace(/\<Unknown\>/g, '').replace(/\<\/Unknown\>/g, '').trim();
 
             // Gathers example's HTML code version
-            const htmlExample = ReactDOMServer.renderToStaticMarkup(component);
-            
+            let htmlExample = ReactDOMServer.renderToStaticMarkup(component);
+            if (component.props.devonly === 'true') {
+              htmlExample = htmlExample.replace(/<(.*)devonly="true">((.|\n)*)<\/(.*)>/m, '$2').trim();
+            }
+
             // Gathers example's used props
             const props = {};
             Object.keys(component.props).map(index => {

--- a/build/scaffolding/elements/[name].example.jsx
+++ b/build/scaffolding/elements/[name].example.jsx
@@ -1,4 +1,10 @@
 /*
+  OPTIONS:
+  The following options are available for Component examples:
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
+
   Example:
     ```
       examples: [{

--- a/build/scaffolding/modifiers/[name].example.jsx
+++ b/build/scaffolding/modifiers/[name].example.jsx
@@ -1,4 +1,10 @@
 /*
+  OPTIONS:
+  The following options are available for Component examples:
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
+
   Example:
     ```
       examples: [{
@@ -10,7 +16,7 @@
           padding: '1rem',
           background: 'path/or/url/to/image(.jpg|.gif|.png|.svg)',
           brightness: 0.5,
-        }        
+        }
       },
     ```
 */

--- a/src/elements/atoms/Button/Button.example.jsx
+++ b/src/elements/atoms/Button/Button.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Heading/Heading.example.jsx
+++ b/src/elements/atoms/Heading/Heading.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```
@@ -29,58 +30,50 @@ export default [{
   examples: [{
     name: 'Light (h1-h6)',
     component: (
-      <React.Fragment>
-        <Rhythm>
-          <Heading level="h1" weight="thin">The brown fox jumps over the h1</Heading>
-          <Heading level="h2" weight="thin">The brown fox jumps over the h2</Heading>
-          <Heading level="h3" weight="thin">The brown fox jumps over the h3</Heading>
-          <Heading level="h4" weight="thin">The brown fox jumps over the h4</Heading>
-          <Heading level="h5" weight="thin">The brown fox jumps over the h5</Heading>
-          <Heading level="h6" weight="thin">The brown fox jumps over the h6</Heading>
-        </Rhythm>
-      </React.Fragment>
+      <Rhythm devonly="true">
+        <Heading level="h1" weight="thin">The brown fox jumps over the h1</Heading>
+        <Heading level="h2" weight="thin">The brown fox jumps over the h2</Heading>
+        <Heading level="h3" weight="thin">The brown fox jumps over the h3</Heading>
+        <Heading level="h4" weight="thin">The brown fox jumps over the h4</Heading>
+        <Heading level="h5" weight="thin">The brown fox jumps over the h5</Heading>
+        <Heading level="h6" weight="thin">The brown fox jumps over the h6</Heading>
+      </Rhythm>
     )
   }, {
     name: 'Medium (h1-h6)',
     component: (
-      <React.Fragment>
-        <Rhythm>
-          <Heading level="h1" weight="medium">The brown fox jumps over the h1</Heading>
-          <Heading level="h2" weight="medium">The brown fox jumps over the h2</Heading>
-          <Heading level="h3" weight="medium">The brown fox jumps over the h3</Heading>
-          <Heading level="h4" weight="medium">The brown fox jumps over the h4</Heading>
-          <Heading level="h5" weight="medium">The brown fox jumps over the h5</Heading>
-          <Heading level="h6" weight="medium">The brown fox jumps over the h6</Heading>
-        </Rhythm>
-      </React.Fragment>
+      <Rhythm devonly="true">
+        <Heading level="h1" weight="medium">The brown fox jumps over the h1</Heading>
+        <Heading level="h2" weight="medium">The brown fox jumps over the h2</Heading>
+        <Heading level="h3" weight="medium">The brown fox jumps over the h3</Heading>
+        <Heading level="h4" weight="medium">The brown fox jumps over the h4</Heading>
+        <Heading level="h5" weight="medium">The brown fox jumps over the h5</Heading>
+        <Heading level="h6" weight="medium">The brown fox jumps over the h6</Heading>
+      </Rhythm>
     )
   }, {
     name: 'Bold (h1-h6)',
     component: (
-      <React.Fragment>
-        <Rhythm>
-          <Heading level="h1" weight="bold">The brown fox jumps over the h1</Heading>
-          <Heading level="h2" weight="bold">The brown fox jumps over the h2</Heading>
-          <Heading level="h3" weight="bold">The brown fox jumps over the h3</Heading>
-          <Heading level="h4" weight="bold">The brown fox jumps over the h4</Heading>
-          <Heading level="h5" weight="bold">The brown fox jumps over the h5</Heading>
-          <Heading level="h6" weight="bold">The brown fox jumps over the h6</Heading>
-        </Rhythm>
-      </React.Fragment>
+      <Rhythm devonly="true">
+        <Heading level="h1" weight="bold">The brown fox jumps over the h1</Heading>
+        <Heading level="h2" weight="bold">The brown fox jumps over the h2</Heading>
+        <Heading level="h3" weight="bold">The brown fox jumps over the h3</Heading>
+        <Heading level="h4" weight="bold">The brown fox jumps over the h4</Heading>
+        <Heading level="h5" weight="bold">The brown fox jumps over the h5</Heading>
+        <Heading level="h6" weight="bold">The brown fox jumps over the h6</Heading>
+      </Rhythm>
     )
   }, {
     name: 'Alternative element tagName',
     component: (
-      <React.Fragment>
-        <Rhythm>
-          <Heading level="h1" tagName="div">The brown fox jumps over the h1</Heading>
-          <Heading level="h2" tagName="div">The brown fox jumps over the h2</Heading>
-          <Heading level="h3" tagName="div">The brown fox jumps over the h3</Heading>
-          <Heading level="h4" tagName="div">The brown fox jumps over the h4</Heading>
-          <Heading level="h5" tagName="div">The brown fox jumps over the h5</Heading>
-          <Heading level="h6" tagName="div">The brown fox jumps over the h6</Heading>
-        </Rhythm>
-      </React.Fragment>
+      <Rhythm devonly="true">
+        <Heading level="h1" tagName="div">The brown fox jumps over the h1</Heading>
+        <Heading level="h2" tagName="div">The brown fox jumps over the h2</Heading>
+        <Heading level="h3" tagName="div">The brown fox jumps over the h3</Heading>
+        <Heading level="h4" tagName="div">The brown fox jumps over the h4</Heading>
+        <Heading level="h5" tagName="div">The brown fox jumps over the h5</Heading>
+        <Heading level="h6" tagName="div">The brown fox jumps over the h6</Heading>
+      </Rhythm>
     )
   }]
 }];

--- a/src/elements/atoms/Icon/Icon.example.jsx
+++ b/src/elements/atoms/Icon/Icon.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Image/Image.example.jsx
+++ b/src/elements/atoms/Image/Image.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Link/Link.example.jsx
+++ b/src/elements/atoms/Link/Link.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/List/List.example.jsx
+++ b/src/elements/atoms/List/List.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/PlaceholderSvg/PlaceholderSvg.example.jsx
+++ b/src/elements/atoms/PlaceholderSvg/PlaceholderSvg.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Rhythm/Rhythm.example.jsx
+++ b/src/elements/atoms/Rhythm/Rhythm.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/RichText/RichText.example.jsx
+++ b/src/elements/atoms/RichText/RichText.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Table/Table.example.jsx
+++ b/src/elements/atoms/Table/Table.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/atoms/Wrapper/Wrapper.example.jsx
+++ b/src/elements/atoms/Wrapper/Wrapper.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Accordion/Accordion.example.jsx
+++ b/src/elements/molecules/Accordion/Accordion.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Brand/Brand.example.jsx
+++ b/src/elements/molecules/Brand/Brand.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Card/Card.example.jsx
+++ b/src/elements/molecules/Card/Card.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Expand/Expand.example.jsx
+++ b/src/elements/molecules/Expand/Expand.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Form/Form.example.jsx
+++ b/src/elements/molecules/Form/Form.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Input/Input.example.jsx
+++ b/src/elements/molecules/Input/Input.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Media/Media.example.jsx
+++ b/src/elements/molecules/Media/Media.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Modal/Modal.example.jsx
+++ b/src/elements/molecules/Modal/Modal.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Select/Select.example.jsx
+++ b/src/elements/molecules/Select/Select.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Tabs/Tabs.example.jsx
+++ b/src/elements/molecules/Tabs/Tabs.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```

--- a/src/elements/molecules/Textarea/Textarea.example.jsx
+++ b/src/elements/molecules/Textarea/Textarea.example.jsx
@@ -1,8 +1,9 @@
 /*
   OPTIONS:
   The following options are available for Component examples:
-    - No Padding variant (noPadding: true)
-    - Dark Background variant (darkBackground: true)
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
 
   Example:
     ```


### PR DESCRIPTION
This adds the ability to set a:
`devonly="true"`

prop on examples wrappers elements to have them be excluded from the html snip under on example pages.

#88 

This also updates example.jsx file head comments to be consistent and factual across existing elements and scaffolding files.