### PR TITLE
Enhance/POSTCSSColorPlugin

### DIFF
--- a/build/configs/css/css.postcss-color.plugin.js
+++ b/build/configs/css/css.postcss-color.plugin.js
@@ -1,0 +1,60 @@
+// Takes a color() function with hex color and alters the hex color.
+
+const postcss = require('postcss');
+module.exports = postcss.plugin('postcss-color', (options) => {
+  options = options || {};
+
+  const HexToRGB = (color) => {
+    color = color.replace('#', '');
+    if (color.length < 6) {
+      color += color;
+    }
+
+    return [
+      parseInt(color.substr(0, 2), 16),
+      parseInt(color.substr(2, 2), 16),
+      parseInt(color.substr(4, 2), 16)
+    ];
+  };
+
+  const RGB_Linear_Shade = (color, percent) => {
+    let intParse = parseInt;
+    let intRound = Math.round;
+
+    let e = (intParse(color[0]) === 0) ? 1 : color[0];
+    let f = (intParse(color[1]) === 0) ? 1 : color[1];
+    let g = (intParse(color[2]) === 0) ? 1 : color[2];
+    let h = (intParse(color[3]) === 0) ? 1 : color[3];
+
+    let q = percent < 0;
+    let t = q ? 0 : 255 * percent;
+    q = q ? 1 + percent : 1 - percent;
+    return [
+      'rgb',
+      (h ? 'a(' : '('),
+      intRound(intParse(e) * (q + t)),
+      ',',
+      intRound(intParse(f) * (q + t)),
+      ',',
+      intRound(intParse(g) * (q + t)),
+      (h ? ',' + h : ')')
+    ].join('');
+  }
+
+  return (root) => {
+    root.walkRules(rule => {
+      rule.walkDecls(decl => {
+        if (decl.value.indexOf('color(') !== -1) {
+          const colors = decl.value.match(/color\((.*?)\)/g);
+          Object.keys(colors).map((index) => {
+            const arguments = colors[index].replace(/^color\((.*?)\)$/, '$1').split(',');
+            const color = (arguments[0].length < 7) ? (arguments[0] + arguments[0].replace('#', '')) : arguments[0];
+            const brightness = (parseInt(arguments[1]) / 100);
+
+            decl.value = decl.value.replace(colors[index], RGB_Linear_Shade(HexToRGB(color), brightness));
+          });
+        }
+      });
+    });
+  };
+});

--- a/build/configs/css/css.postcss.config.js
+++ b/build/configs/css/css.postcss.config.js
@@ -22,6 +22,7 @@ const resolver = ResolverFactory.createResolver({
 // however always read newly added plugin docs to make sure they don't carry their own order of operation requirements.
 // standard
 const rems = require('./css.postcss-rem.plugin.js');
+const color = require('./css.postcss-color.plugin.js');
 const media = require('./css.postcss-media.plugin.js');
 const nested = require('postcss-nested');
 const extend = require('./css.postcss-extend.plugin.js');
@@ -47,6 +48,7 @@ module.exports = {
     media(),        // Allows for custom media queries
     exporting(),    // Pre-parse color variables
     variables(),    // Allows var(--variables)
+    color(),        // Allows for color(hex or var(), darken | lighten)
     custom(),       // Allows for @custom selectors
     respondType(),  // Allows for responsive typography
     nested(),       // Allows for nested selectors

--- a/build/guide/partials/examples/guide__examples.css
+++ b/build/guide/partials/examples/guide__examples.css
@@ -4,7 +4,7 @@
 
   & .examples {
     &__list {
-      & > div { 
+      & > div {
         display: inline-block;
         width: 100%;
       }
@@ -24,13 +24,13 @@
         left: 0;
         width: 100%;
         height: 100%;
-        z-index: 1;        
+        z-index: 1;
       }
 
       &:before {
         background: var(--background);
         opacity: var(--brightness);
-      }      
+      }
 
       &-inner {
         position: relative;
@@ -51,7 +51,7 @@
 
     &__codes {
       pre {
-        background-color: var(--color--alpha05);
+        background-color: color(var(--color-black), 95%);
         margin-top: 1rem;
         max-height: 320px;
         overflow-x: scroll;
@@ -61,7 +61,7 @@
     }
 
     &__header {
-      background-color: var(--color--alpha05);
+      background-color: color(var(--color-black), 95%);
 
       a {
         font-size: 0.875rem;
@@ -115,12 +115,12 @@
     &__footer {
       display: flex;
       flex-direction: column;
-      
+
       .button {
         margin: 0 0.5rem;
         &:first-child { margin-left: 0; }
         &:last-child { margin-right: 0; }
       }
-    }  
+    }
   }
 }

--- a/build/guide/partials/nav/guide__nav.css
+++ b/build/guide/partials/nav/guide__nav.css
@@ -8,7 +8,7 @@
   width: 100%;
 
   &.open {
-    background-color: var(--color--alpha25);
+    background-color: rgba(0, 0, 0, 0.25);
     transform: rotateY(0);
   }
 
@@ -19,8 +19,8 @@
   .guide-nav__open {
     &:after {
       background-color: var(--color-white);
-      border: 1px solid var(--color--alpha25);
-      box-shadow: 2px 4px 10px 0 var(--color--alpha15);
+      border: 1px solid color(var(--color-black), 75%);
+      box-shadow: 2px 4px 10px 0 color(var(--color-black), 85%);
       content: url('assets/menu.svg');
       cursor: pointer;
       display: block;
@@ -131,7 +131,7 @@
   }
 
   & .heading {
-    background-color: var(--color--alpha05);
+    background-color: color(var(--color-black), 95%);
     background-position: 10px center;
     background-repeat: no-repeat;
     background-size: 25px;
@@ -189,7 +189,7 @@
   .modal-inner {
     &--width {
       background: transparent;
-      box-shadow: 0 rem(20px) rem(20px) 0 var(--color--alpha25);
+      box-shadow: 0 rem(20px) rem(20px) 0 color(var(--color-black), 75%);
     }
   }
 

--- a/build/guide/partials/readme/guide__readme.css
+++ b/build/guide/partials/readme/guide__readme.css
@@ -40,7 +40,7 @@
       &s {
         display: flex;
         justify-content: space-between;
-        flex-wrap: wrap; 
+        flex-wrap: wrap;
         @media (--medium) {
           flex-wrap: nowrap;
         }
@@ -48,7 +48,7 @@
 
       & .heading {
         border: 1px solid var(--color-gray);
-        padding: 1rem;      
+        padding: 1rem;
       }
     }
 
@@ -58,7 +58,7 @@
       transition: opacity 0.25s, height 0.25s;
 
       &__head {
-        background-color: var(--color--alpha05);
+        background-color: color(var(--color-black), 95%);
         &er {
           border-top: 1px solid var(--color-gray);
           border-bottom: 1px solid var(--color-gray);

--- a/build/guide/partials/stylist/guide__stylist.css
+++ b/build/guide/partials/stylist/guide__stylist.css
@@ -2,8 +2,8 @@
 .guide {
   &__stylist {
     background-color: var(--color-white);
-    border: 1px var(--color--alpha25) solid;
-    box-shadow: 2px 4px 10px 0px var(--color--alpha25);
+    border: 1px vcolor(var(--color-black), 75%) solid;
+    box-shadow: 2px 4px 10px 0px color(var(--color-black), 75%);
     max-width: 320px;
     position: fixed;
     right: 2rem;
@@ -49,7 +49,7 @@
             display: block;
           }
         }
-      }       
+      }
     }
 
     &-inner {
@@ -85,7 +85,7 @@
         display: inline-block;
         height: 10px;
         margin-right: rem(5px);
-        width: 10px;        
+        width: 10px;
       }
 
       &.guide__stylist-js-stat {

--- a/src/elements/atoms/Select/Select.css
+++ b/src/elements/atoms/Select/Select.css
@@ -88,7 +88,11 @@
 		.sub-field__decorator {
 			background-color: var(--color-white);
 			width: 100%;
-			box-shadow: 0 0 0 rem(1px) var(--color-gray), 0 rem(5px) rem(5px) rem(-3px) var(--color--alpha25), 0 rem(8px) rem(10px) rem(1px) var(--color--alpha15), 0 rem(3px) rem(14px) rem(2px) var(--color--alpha05);
+			box-shadow:
+        0 0 0 rem(1px) var(--color-gray),
+        0 rem(5px) rem(5px) rem(-3px) color(var(--color-black), 75%),
+        0 rem(8px) rem(10px) rem(1px) color(var(--color-black), 85%),
+        0 rem(3px) rem(14px) rem(2px) color(var(--color-black), 95%);
 
 			.list__item {
 				border-bottom: rem(1px) solid var(--color-gray-light);

--- a/src/elements/molecules/Modal/Modal.css
+++ b/src/elements/molecules/Modal/Modal.css
@@ -6,7 +6,7 @@
 }
 
 .modal {
-	background: var(--color--alpha25);
+	background: rgba(0, 0, 0, 0.25);
 	bottom: 0;
 	display: none;
 	left: 0;
@@ -66,8 +66,8 @@
 			transform: scale(1);
 			transition: opacity 0.2s, transform 0.2s;
 			z-index: 100;
-		}		
-	}	
+		}
+	}
 
 	&-inner {
 		padding: 4rem 1rem 2rem;
@@ -83,7 +83,7 @@
 			transition: opacity 0.2s, transform 0.2s, z-index 0s 0.2s;
 			width: 100%;
 		  justify-content: center;
-			z-index: -1;	
+			z-index: -1;
 			@media (--large) {
 				margin: 0;
 			}

--- a/src/variables/colors.css
+++ b/src/variables/colors.css
@@ -24,18 +24,9 @@
   --color-gray-light: #dcdcdc;
   --color-gray: #8c8c8c;
   --color-gray-dark: #4c4c4c;
-  --color-black: #000;
+  --color-black: #000000;
 
   /* text colors */
   --color-text--primary: var(--color-black);
   --color-text--secondary: var(--color-white);
-
-  /* translucents */
-  --color--alpha100: rgb(0, 0, 0, 1);
-  --color--alpha80: rgb(0, 0, 0, 0.8);
-  --color--alpha50: rgb(0, 0, 0, 0.5);
-  --color--alpha25: rgb(0, 0, 0, 0.25);
-  --color--alpha15: rgb(0, 0, 0, 0.15);
-  --color--alpha05: rgb(0, 0, 0, 0.05);
-  --color--alpha00: rgb(0, 0, 0, 0.00);
 }


### PR DESCRIPTION
First pass at new inhouse CSS color() function.
This new css function allows you to pass:
```css
color(#fff, -50%)
color(#ffffff, -50%)
color(var(--color-white), -50%)

color(#000, 50%)
color(#000000, 50%)
color(var(--color-black), 50%)
```
Take note you can pass a shorthand hex, long hand hex, variable hex. Lighten and darken has been broken down into a range between -100% and 100%.

Alpha transparency not supported.
Only hex color format is supported.

#104