### PR TITLE
Elements and Mixin Updates

### DIFF
--- a/build/configs/css/css.postcss.config.js
+++ b/build/configs/css/css.postcss.config.js
@@ -34,15 +34,17 @@ module.exports = {
     }),
     Plugins.exporting(),     // Pre-parse color variables
     nested(),                // Allows for nested selectors
-    custom()                 // Allows for @custom selectors
+    custom()                // Allows for @custom selectors
   ],
   postBundle: [
+    Plugins.mixins(),        // Allows for CSS @mixins
+    nested(),                // Allows for nested selectors
     Plugins.rems(),          // Allows for CSS rem()
     Plugins.variables(),     // Allows var(--variables)
+    Plugins.percentage(),    // Allows quick conversion of number to percentage
     Plugins.colors(),        // Allows for color(hex or var(), darken | lighten)
     Plugins.extend(),        // Allows for CSS @extend
     Plugins.media(),         // Allows for custom media queries
-    mixins(),                // Allows for CSS @mixins
     Plugins.roots(),         // Cleans up leftover :root declarations.
     Plugins.comments(),      // Cleans up comments.
     (Package.optimize.css)   // Minification of our final CSS results.

--- a/build/configs/css/css.postcss.config.js
+++ b/build/configs/css/css.postcss.config.js
@@ -3,7 +3,6 @@ const Alias = require('../alias.config.js');
 const Plugins = require('./css.postcss.plugins.js');
 const nested = require('postcss-nested');
 const custom = require('postcss-custom-selectors');
-const mixins = require('postcss-mixins');
 const imports = require('postcss-import');
 
 // start enhanced-resolve setup DO NOT CHANGE! (allows alias namespaces within postcss)

--- a/build/configs/css/css.postcss.config.js
+++ b/build/configs/css/css.postcss.config.js
@@ -32,7 +32,6 @@ module.exports = {
       }
     }),
     Plugins.exporting(),     // Pre-parse color variables
-    nested(),                // Allows for nested selectors
     custom()                // Allows for @custom selectors
   ],
   postBundle: [

--- a/build/configs/webpack.plugins.js
+++ b/build/configs/webpack.plugins.js
@@ -107,7 +107,7 @@ class StaticBundle {
 
           const fileless = example.staticPath.substring(0, example.staticPath.lastIndexOf("/"));
           const dest = path.resolve(__dirname, `${Package.statics.dest}${fileless}`).replace(/\\/g, '/');
-          console.log(dest);
+
           fs.ensureDirSync(dest);
 
           // second write files to newly created dest directories

--- a/build/guide/partials/nav/guide__nav.container.js
+++ b/build/guide/partials/nav/guide__nav.container.js
@@ -7,6 +7,7 @@ export const GuideNav = (el) => {
     navInner: document.querySelector('.guide__nav-inner'),
     navLists: document.querySelectorAll('.heading + .list'),
     search: el.querySelector('.guide__nav--search .field__native'),
+    newElement: document.querySelector('.new-element .input-text .field__native'),
     renameElementTrigger: document.querySelectorAll('[data-modal="rename"]:not(.modal)'),
     removeElementTrigger: document.querySelectorAll('[data-modal="remove"]:not(.modal)')
   };
@@ -34,15 +35,11 @@ export const GuideNav = (el) => {
         // navigation accordion
         if (target.classList.contains('heading')) {
           if (target.classList.contains('home')) { return; }
-          if (target.nextSibling.classList.contains('hidden')) {
-            target.nextSibling.classList.remove('hidden');
-          } else {
-            target.nextSibling.classList.add('hidden');
-          }
-
+          Utils.toggleClass(target.nextSibling, 'hidden');
           e.preventDefault();
         }
 
+        // rename / remove element
         if (target.dataset) {
           if (target.dataset.modal === 'rename') {
             const renameElementForm = document.querySelector('[data-modal="rename"] form');
@@ -53,6 +50,7 @@ export const GuideNav = (el) => {
           if (target.dataset.modal === 'remove') {
             const removeElementForm = document.querySelector('[data-modal="remove"] form');
             removeElementForm.querySelector('[name="path"]').value = target.dataset.path; // eslint-disable-line
+            renameElementForm.querySelector('[name="location"]').value = target.dataset.location; // eslint-disable-line
           }
         }
       });
@@ -117,7 +115,6 @@ export const GuideNav = (el) => {
       });
     }
 
-    ui.newElement = document.querySelector('.new-element .input-text .field__native');
     if (ui.newElement) {
       ui.newElementType = document.querySelector('.new-element .select');
       ui.newElementTypeNative = ui.newElementType.querySelector('.field__native');

--- a/build/guide/partials/nav/guide__nav.jsx
+++ b/build/guide/partials/nav/guide__nav.jsx
@@ -51,6 +51,7 @@ const getElementListing = (examples, level) => Object.keys(examples).map((i) => 
                 title="Delete element"
                 data-modal="remove"
                 data-path={`src/elements/${level}/${examples[i].name}`}
+                data-location={(window.location.pathname.indexOf(examples[i].name)) ? '/' : window.location.pathname}
               >
                 <Icon name="trash" />
               </Link>
@@ -284,6 +285,7 @@ export const Guide__nav = (props) => {
                       <Fieldset legend="Use the form below to delete an element">
                         <Input type="hidden" label={false} name="name" id="delete-name" required />
                         <Input type="hidden" label={false} name="path" id="delete-path" />
+                        <Input type="hidden" label={false} name="location" id="delete-location" />
                         <Input type="hidden" label={false} name="remove" id="delete-remove" value="true" />
                         <Button type="submit">Yes</Button>
                         <Button href="#/" data-modal-close="true">No</Button>

--- a/build/scaffolding/scaffolding.build.js
+++ b/build/scaffolding/scaffolding.build.js
@@ -197,7 +197,7 @@ class RemoveAtomicElement {
   }
 
   removeElement() {
-    rimraf(path.resolve(__dirname, ['../../', type].join('')), () => {
+    rimraf(path.resolve(__dirname, `../../${type}`), () => {
       triggerRebuild();
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5294,6 +5294,17 @@
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true
 		},
+		"fs-extra": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
+			"integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -7426,6 +7437,15 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsx-ast-utils": {
@@ -12909,6 +12929,12 @@
 			"requires": {
 				"unist-util-is": "^2.1.2"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"postcss-custom-selectors": "^5.1.2",
 		"postcss-import": "^11.1.0",
 		"postcss-loader": "^2.1.6",
-		"postcss-mixins": "^6.2.1",
 		"postcss-nested": "^3.0.0",
 		"pretty": "^2.0.0",
 		"prismjs": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"eslint-plugin-react": "^7.12.4",
 		"extract-comment": "^1.1.1",
 		"file-loader": "^1.1.11",
+		"fs-extra": "^8.0.1",
 		"hard-source-webpack-plugin": "^0.13.1",
 		"html-loader": "^0.5.5",
 		"html-webpack-plugin": "^4.0.0-beta.5",

--- a/src/elements/atoms/Image/Image.css
+++ b/src/elements/atoms/Image/Image.css
@@ -1,9 +1,10 @@
 .image {
   position: relative;
+  width: 100%;
 
   &--auto {
-    width: 100%;
+    max-width: 100%;
+    width: auto;
     height: auto;
   }
 }
-

--- a/src/elements/atoms/Image/Image.example.jsx
+++ b/src/elements/atoms/Image/Image.example.jsx
@@ -29,14 +29,12 @@ import Image from './Image';
 export default [{
   examples: [
     {
-      name: 'Default image behavior',
+      name: 'Default Image',
       component: (
-        <Image src={imageSrc} alt="Rancheria Falls" />
-      )
-    }, {
-      name: 'Auto sizing variant',
-      component: (
-        <Image src={imageSrc} variant="auto" alt="Rancheria Falls" />
+        <Image
+          src={imageSrc}
+          alt="Rancheria Falls"
+        />
       )
     }, {
       name: 'Default Image with srcset',
@@ -44,9 +42,13 @@ export default [{
         <Image
           src={imageSrc}
           srcSet={`${imageSrcMd} 720w, ${imageSrcLg} 1440w`}
-          variant="auto"
           alt="Rancheria Falls"
         />
+      )
+    }, {
+      name: 'Auto size Image behavior',
+      component: (
+        <Image src={imageSrc} alt="Rancheria Falls" variant="auto" />
       )
     }
   ]

--- a/src/elements/atoms/Video/Video.css
+++ b/src/elements/atoms/Video/Video.css
@@ -1,0 +1,32 @@
+:root {
+
+  /* CSS variables */
+}
+
+.video {
+
+  /* Baseline styles */
+  &__player {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+  }
+
+  /* Style variants */
+
+  /* Ratio variants */
+  &--default {
+    @mixin aspect-ratio 16, 9;
+  }
+
+  &--wide {
+    @mixin aspect-ratio 21, 9;
+  }
+
+  &--tall {
+    @mixin aspect-ratio 4, 3;
+  }
+}

--- a/src/elements/atoms/Video/Video.example.jsx
+++ b/src/elements/atoms/Video/Video.example.jsx
@@ -1,0 +1,54 @@
+/*
+  OPTIONS:
+  The following options are available for Component examples:
+    - No Padding variant (padding: true|false)
+    - Background Image (background: path|blank)
+    - Dark Background variant (brightness: 0.0-1.0)
+
+  Example:
+    ```
+      examples: [{
+        name: 'Default styling',
+        component: (
+          <Component>Lorem ipsum</Component>
+        ),
+        options: {
+          padding: '1rem',
+          background: 'path/or/url/to/image(.jpg|.gif|.png|.svg)',
+          brightness: 0.5,
+        }
+      },
+    ```
+*/
+
+import Video from './Video';
+
+export default [{
+  examples: [
+    {
+      name: 'Default Ratio 16:9',
+      description: '',
+      staticPath: '',
+      component: (
+        <Video src="https://www.youtube.com/embed/XSGBVzeBUbk" ratio="default" />
+      ),
+      notes: ''
+    }, {
+      name: 'Wide Ratio 21:9',
+      description: '',
+      staticPath: '',
+      component: (
+        <Video src="https://www.youtube.com/embed/XSGBVzeBUbk" ratio="wide" />
+      ),
+      notes: ''
+    }, {
+      name: 'Tall ratio 4:3',
+      description: '',
+      staticPath: '',
+      component: (
+        <Video src="https://www.youtube.com/embed/XSGBVzeBUbk" ratio="tall" />
+      ),
+      notes: ''
+    }
+  ]
+}];

--- a/src/elements/atoms/Video/Video.jsx
+++ b/src/elements/atoms/Video/Video.jsx
@@ -1,0 +1,75 @@
+/**
+  The video component is a simplified abstraction of the youtube iframe embed
+*/
+
+export class Video extends React.Component {
+  static propTypes = {
+    /** Tag overload */
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+      PropTypes.func
+    ]),
+    /** Class stacking */
+    className: PropTypes.string,
+    /** Style variants */
+    variant: PropTypes.oneOf(['default']),
+    /** Children passed through */
+    children: PropTypes.node,
+    /** Defines the video source */
+    src: PropTypes.string,
+    /** Define video's title */
+    title: PropTypes.string,
+    /** Defines the video ratio */
+    ratio: PropTypes.oneOf(['default', 'wide', 'tall'])
+  };
+
+  static defaultProps = {
+    tagName: 'div',
+    variant: 'default',
+    ratio: 'default',
+    title: ''
+  };
+
+  /** Element level options */
+  static options = {};
+
+  render = () => {
+    const {
+      tagName: Tag,
+      className,
+      variant,
+      children,
+      title,
+      ratio,
+      src,
+      ...attrs
+    } = this.props;
+
+    const classStack = Utils.createClassStack([
+      'video',
+      `video--${variant}`,
+      `video--${ratio}`,
+      className
+    ]);
+
+    return (
+      <Tag
+        className={classStack}
+        {...attrs}
+      >
+        <iframe
+          className="video__player"
+          src={src}
+          frameBorder="0"
+          title={title}
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+        {children}
+      </Tag>
+    );
+  }
+}
+
+export default Video;

--- a/src/elements/atoms/Video/Video.test.jsx
+++ b/src/elements/atoms/Video/Video.test.jsx
@@ -1,0 +1,12 @@
+import test from 'tape';
+import { shallow } from 'enzyme';
+
+import Video from './Video';
+
+test('<Video>', (t) => {
+  const component = shallow(<Video>Hello World</Video>);
+  t.ok(component.is('div'), 'tag name');
+  t.ok(component.is('.video'), 'tag class');
+  t.equal(component.text(), 'Hello World', 'text');
+  t.end();
+});

--- a/src/styles.js
+++ b/src/styles.js
@@ -4,6 +4,7 @@ const requireAll = (context) => context.keys().map(context);
 require('@vars/breakpoints.css');
 require('@vars/colors.css');
 require('@vars/custom-selectors.css');
+require('@vars/mixins.css');
 require('@vars/fonts.css');
 require('@vars/type.css');
 require('@vars/zindex.css');

--- a/src/variables/mixins.css
+++ b/src/variables/mixins.css
@@ -1,0 +1,18 @@
+/*
+  Aspect Ratio
+  Usage example:
+
+  @mixin aspect-ratio 4, 3;
+*/
+
+@define-mixin aspect-ratio var(--width), var(--height) {
+  position: relative;
+
+  &:before {
+    content: '';
+    display: block;
+    padding-top: percentage(var(--height) / var(--width));
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,6 +3925,15 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
+fs-extra@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
+  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -4214,7 +4223,7 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -5317,6 +5326,13 @@ json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsx-ast-utils@^2.0.1:
   version "2.0.1"
@@ -9184,6 +9200,11 @@ unist-util-visit@^1.1.0:
   integrity sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- New in house mixins plugin that works under a post bundle sheet vs prebundle sheet. This does away with any requirements/limitations around variable usage found in the community version.
- New in house percentage postcss plugin that evals a CSS calc down to a percent number.
- New aspect-ratio mixin under variables/mixins.css.
- Fixes Image atom variants of default vs. auto
- Adds fs-extra for more efficient way to do recursive folder building during static builds.
- Relocates nesting postcss plugin to postBundle instead of preBundle process.